### PR TITLE
Adding an old Dutch emergency number.

### DIFF
--- a/firmware/TeleJukebox/TeleJukebox.ino
+++ b/firmware/TeleJukebox/TeleJukebox.ino
@@ -520,7 +520,7 @@ unsigned char CheckSequence(String str)
   Serial.println(str);
 
   /*special number sequence handling*/
-  if((str == "911") || (str == "112") || (str == "09008844") || (str == "999") || (str == "01189998819991197253"))    /*Check for emergency number, if so, warn user that this phone cannot be used*/
+  if((str == "911") || (str == "112") || (str == "09008844") || (str == "999") || (str == "01189998819991197253") || (str == "0611"))    /*Check for emergency number, if so, warn user that this phone cannot be used*/
   {
     Serial.println("You've dialed an alarm related number");
     myDFPlayer.stop();                    /*song has ended, play the disconnected sound*/


### PR DESCRIPTION
Prior to September 1997 the emergency number in The Netherlands was 0611. With the intended audience this is probably a good addition to the 'special number sequence handling'.